### PR TITLE
Prevent freezing by adding a divide by zero check for the steps flag

### DIFF
--- a/hypr-zoom.go
+++ b/hypr-zoom.go
@@ -13,7 +13,7 @@ import (
 )
 
 type EasingFunction func(t float64) float64
-type InterpolatorFunc func(s , e, t float64) float64
+type InterpolatorFunc func(s, e, t float64) float64
 
 // Linear interpolation function
 func lerp(start, end, t float64) float64 {
@@ -21,10 +21,10 @@ func lerp(start, end, t float64) float64 {
 }
 
 func logInterp(start, end, t float64) float64 {
-    if t == 0 {
-        return start
-    }
-    return start + (end-start)*(math.Log(t+1)/math.Log(2))
+	if t == 0 {
+		return start
+	}
+	return start + (end-start)*(math.Log(t+1)/math.Log(2))
 }
 
 // Main animation loop
@@ -62,7 +62,7 @@ func main() {
 	easing := flag.String("easing", "InOutExpo", "Easing function to use")
 	easingOut := flag.String("easingOut", "", "Easing function to use for zoom-out (optional)")
 	targetZoom := flag.Float64("target", 2.0, "Zoom Target")
-  interpolator := flag.String("interp","Log", "Animation interpolator function")
+	interpolator := flag.String("interp", "Log", "Animation interpolator function")
 	flag.Parse()
 
 	initialZoom, err := strconv.ParseFloat(strings.TrimSpace(output), 64)
@@ -108,18 +108,16 @@ func main() {
 		"InOutSquare": ease.InOutSquare,
 	}
 
-  interpolatorFunctions := map[string] InterpolatorFunc{
-    "Log": logInterp,
-    "Linear": lerp,
-  }
+	interpolatorFunctions := map[string]InterpolatorFunc{
+		"Log":    logInterp,
+		"Linear": lerp,
+	}
 
-  interpolatorFunc, exists := interpolatorFunctions[*interpolator]
-  if !exists {
+	interpolatorFunc, exists := interpolatorFunctions[*interpolator]
+	if !exists {
 		fmt.Println("Unknown interpolator function:", *interpolator, "Set to default")
-    interpolatorFunc = interpolatorFunctions["Log"]
-  }
-
-
+		interpolatorFunc = interpolatorFunctions["Log"]
+	}
 
 	easingFunction, exists := easingFunctions[*easing]
 	if !exists {

--- a/hypr-zoom.go
+++ b/hypr-zoom.go
@@ -71,6 +71,11 @@ func main() {
 		return
 	}
 
+	if *steps <= 0 {
+		fmt.Println("Error: `steps` must be greater than 0.")
+		return
+	}
+
 	easingFunctions := map[string]EasingFunction{
 		"Linear":     ease.Linear,
 		"InQuad":     ease.InQuad,


### PR DESCRIPTION
Running `hypr-zoom -steps 0` results in my terminal freezing and locking my cursor. Fixed by adding a check to ensure that `steps` flag is positive.

This prevents other users from assuming that "steps = 0" results in instantaneous zoom.


Additionally, `go fmt` was ran to fix white-space use.

Sorry for the messy diff from formatting.

Thanks.